### PR TITLE
add python3.12 support by removing upper limit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 packages = [{ include = "simple_pytree" }]
 
 [tool.poetry.dependencies]
-python = ">=3.8,<3.12"
+python = ">=3.8"
 jax = "*"
 jaxlib = "*"
 typing-extensions = "*"


### PR DESCRIPTION
Since Ubuntu 24.04 LTS uses Python3.12, I needed to remove the upper limit in the supported version. There haven't been any issues so far.

resolves #15 